### PR TITLE
Issue #60 - Add logo to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,14 +369,4 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/rhapso
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
 
-<!-- necessary legalese - because, legal, you know -->
-<sub><sup>
-Napster and Napster logo are registered and unregistered trademarks of Rhapsody International in the United States and/or other countries.</sup></sub>
-
-<sub><sup>
-All company, product and service names used in this website are for identification purposes only.
-</sup></sub>
-
-<sub><sup>
-All product names, logos, and brands are property of their respective owners.
-</sup></sub>
+Napster and Napster logo are registered and unregistered trademarks of Rhapsody International in the United States and/or other countries. All company, product and service names used in this website are for identification purposes only.  All product names, logos, and brands are property of their respective owners.


### PR DESCRIPTION
Patches Issue #60 - by adding the Napster logo to the Readme page.

Added some comments in the README to show where we'd add badges (when we have them) and a contact link like [other README's](https://github.com/petkaantonov/bluebird/blob/master/README.md) have 
