### PR TITLE
Fix #67: `client.refresh` without connecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ it is expired.
 through authentication after the old access_token expires.*
 
 ```ruby
+client_hash = {
+  api_key: 'API_KEY',
+  api_secret: 'API_SECRET',
+  refresh_token: 'REFRESH_TOKEN'
+}
+
+client = Napster::Client.new(client_hash)
 client.refresh # => returns new access_token by refreshing it
 ```
 

--- a/lib/napster/client.rb
+++ b/lib/napster/client.rb
@@ -154,6 +154,17 @@ module Napster
       Napster::Me.new(self)
     end
 
+    # Refresh access token
+    def refresh
+      validate_refresh
+      body = post('/oauth/access_token', refresh_post_body, {})
+      @access_token = body['access_token']
+      @refresh_token = body['refresh_token']
+      @expires_in = body['expires_in']
+
+      self
+    end
+
     private
 
     # Helper method for .new, choose authentication method, and authenticate
@@ -194,6 +205,12 @@ module Napster
       end
     end
 
+    def validate_refresh
+      raise Error, 'api_key is missing' unless @api_key
+      raise Error, 'api_secret is missing' unless @api_secret
+      raise Error, 'refresh_token is missing' unless @refresh_token
+    end
+
     def auth_password_grant
       validate_auth_password_grant
       body = post('/oauth/token',
@@ -212,6 +229,16 @@ module Napster
         grant_type: 'password',
         username: @username,
         password: @password
+      }
+    end
+
+    def refresh_post_body
+      {
+        client_id: @api_key,
+        client_secret: @api_secret,
+        response_type: 'code',
+        grant_type: 'refresh_token',
+        refresh_token: @refresh_token
       }
     end
 

--- a/spec/client_spec_helper.rb
+++ b/spec/client_spec_helper.rb
@@ -57,4 +57,11 @@ module ClientSpecHelper
     playlists = client.me.playlists.all(params)
     !playlists.empty?
   end
+
+  def self.prepare_refresh_token
+    includes = %w(username password)
+    client = ClientSpecHelper.get_client(includes)
+    client.authenticate(:password_grant)
+    client.refresh_token
+  end
 end

--- a/spec/lib/napster/client_spec.rb
+++ b/spec/lib/napster/client_spec.rb
@@ -33,6 +33,20 @@ describe Napster::Client do
       expect(client.access_token).to_not be_nil
     end
 
+    it 'with api_key, api_secret, refresh_token' do
+      refresh_token = ClientSpecHelper.prepare_refresh_token
+      options = {
+        api_key: config_variables['API_KEY'],
+        api_secret: config_variables['API_SECRET'],
+        refresh_token: refresh_token
+      }
+      client = Napster::Client.new(options)
+
+      expect(client.api_key).to_not be_nil
+      expect(client.api_secret).to_not be_nil
+      expect(client.refresh_token).to_not be_nil
+    end
+
     it 'without attributes' do
       options = {
         api_key: Faker::Lorem.characters(20),
@@ -313,5 +327,20 @@ describe Napster::Client do
     client = Napster::Client.new(options)
 
     expect(client.me.class).to eql(Napster::Me)
+  end
+
+  it '#refresh' do
+    refresh_token = ClientSpecHelper.prepare_refresh_token
+    options = {
+      api_key: config_variables['API_KEY'],
+      api_secret: config_variables['API_SECRET'],
+      refresh_token: refresh_token
+    }
+    client = Napster::Client.new(options)
+    client.refresh
+
+    expect(client.access_token).to_not be_nil
+    expect(client.refresh_token).to_not be_nil
+    expect(client.expires_in).to_not be_nil
   end
 end

--- a/spec/lib/napster/me_spec.rb
+++ b/spec/lib/napster/me_spec.rb
@@ -233,7 +233,7 @@ describe Napster::Me do
       }
       playlist = client.me.playlists.create(playlist_hash)
       playlist_ids << playlist.id
-      privacy_value = rand(0..1) == 0 ? true : false
+      privacy_value = rand(0..1).zero? ? true : false
 
       client.me.playlists.set_private(playlist.id, privacy_value)
       updated_playlist = client.me.playlists.find(playlist.id)


### PR DESCRIPTION
https://github.com/Napster/napster-ruby/issues/67

This PR supports this use case below. This use case is needed because you need to be able to refresh access token without an access token.

``` ruby
client_hash = {
  api_key: 'API_KEY',
  api_secret: 'API_SECRET',
  refresh_token: 'REFRESH_TOKEN'
}

client = Napster::Client.new(client_hash)
client.refresh # => returns new access_token by refreshing it
```
